### PR TITLE
Fixed Memory leak in getFrameData function

### DIFF
--- a/src/aditof_utils.cpp
+++ b/src/aditof_utils.cpp
@@ -293,8 +293,6 @@ void getNewFrame(const std::shared_ptr<Camera> &camera, aditof::Frame **frame) {
 uint16_t *getFrameData(aditof::Frame **frame, const std::string &dataType) {
     uint16_t *frameData;
     Status status = Status::OK;
-    aditof::Frame *test;
-    test = new Frame;
 
     status = (*frame)->getData(dataType, &frameData);
 


### PR DESCRIPTION
Fixed memory leak for **test** variable.
The memory allocated using **new** operator is not getting freed.
Since the variable is not being used, removed it.

Signed-off-by: Meet Gandhi <meetgandhi168@gmail.com>